### PR TITLE
Added --user to pip command

### DIFF
--- a/src/install.py
+++ b/src/install.py
@@ -26,10 +26,9 @@ import os
 if sys.version_info < (3, 5):
     raise Exception("ERROR: Python 3.5 or more is required, you are currently running Python %d.%d!" %
                     (sys.version_info[0], sys.version_info[1]))
-try: 
+try:
     from jinja2 import Environment, FileSystemLoader
 except:
     print("missing jinja2:")
     print ("Trying to Install required module: jinja2")
-    os.system('python3 -m pip install jinja2')
-
+    os.system('python3 -m pip install --user jinja2')


### PR DESCRIPTION
Adding --user to the pip command will cause the
libraries to be installed in user space not in
system space making it so user don't have to run
the scrip with super user permission.

Signed-off-by: George Nash <george.nash@intel.com>