### PR TITLE
Add in notification code

### DIFF
--- a/src/templates/C++IotivityServer/readme.md
+++ b/src/templates/C++IotivityServer/readme.md
@@ -2,12 +2,12 @@
 
 The generated code acts as an simulator:
 - it creates values at start update
-- handles incoming requests, 
+- handles incoming requests,
     - stores the values on POST
     - respond on GET by giving out the stored values
 
 ## what is generated:
-        
+
 - server.cpp implementation code
     - per resource an class is generated.
         - constructor
@@ -15,24 +15,26 @@ The generated code acts as an simulator:
         - has entity handler
             - get function to use the variables to create the return payload
             - post function to assign the variables from the request payload
-                - single type: integer, number and strings 
-                - arrays 
+                - single type: integer, number and strings
+                - arrays
                     - array members are set for an GET
                     - array members are retrieved from an POST
                     - only arrays of a single type are handled.
                         e.g. array of int, array of strings, array of number
                         NOT handled: array of objects.
                         - TODO: add complex objecs, see garage example of how to next objects (see client and server side)
-                - checks on minimum, maximum and readOnly, no update of the value if this occurs 
+                - checks on minimum, maximum and readOnly, no update of the value if this occurs
+                - tells the notify thread to send out a notification when a member is UPDATED
                 - check if the correct interface is used (oic.if.a or oic.if.rw)
-    - main 
+        - has a notifyObservers function that is run in a thread at startup.
+    - main
         - creates all classes
         - creates the device
         - installs the reader for
             - introspection device data file (IDD)
             - security file (SVR) contents
             these files needs to be installed/copied where the the executable is.
-           
+
 - svr_server.json  - not used !!!
     default json definition of the secure virtual resources (svr)
     - just works
@@ -45,19 +47,17 @@ The generated code acts as an simulator:
 - PICS.json
     - pics for CTT testing
     - security: just works.
- 
-          
-            
+
+
+
 ## what is missing/incorrect:
 - handling query params (none interfaces)
-- handling observe
 - manual update of resource data, e.g. out of bounds so that one can trigger this to pass CTT.
 - creation/deletion of resources (PUT/DELETE functions)
 - no correct makefile/scons file, so we do not yet know how to insert this in the IOTivity tree and then compile
     - see for manual changes below
 
 # notes:
-- only tested on windows
 - readOnly params like: "precision", "maximumsaturation" from oic.r.colour.chroma is crashing the device when running the CTT
     - to avoid this: remove these properties from the generated device.
 
@@ -105,7 +105,7 @@ new :
 # Source files and Targets
 ######################################################################
 example_names = [
-    'server', 
+    'server',
     ]
 
 if target_os not in ['windows', 'msys_nt']:
@@ -157,7 +157,7 @@ run.bat server
 ## CTT info
 
 When CTT pops up:
-"reset to onboarding state" means one needs to: 
+"reset to onboarding state" means one needs to:
 1. Stop your device
 2. Reset/replace security databases with a new/unowned one.
     e.g. copy the ORIGINAL security file to the executable directory.
@@ -172,10 +172,6 @@ this is mentioned in the test case log of CTT when the CTT can't reset the devic
 - IOTivity implements the next optional virtual security resources
     currently there is no mechanism available to remove those from the implementatino.
     hence they must be listed in the PICS:
-    - oic.r.crl, oic.r.csr, oic.r.roles 
+    - oic.r.crl, oic.r.csr, oic.r.roles
 - oic/res
     This resource must be listed as none observable.
-    
-    
-
-

--- a/src/templates/C++IotivityServer/server.cpp.jinja2
+++ b/src/templates/C++IotivityServer/server.cpp.jinja2
@@ -18,7 +18,9 @@
 //
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 #include <signal.h>
+#include <atomic>
 #include <thread>
+#include <condition_variable>
 #include <functional>
 #include <string>
 #include <iostream>
@@ -124,6 +126,11 @@ class {{path|classsyntax}}Resource : public Resource
          * constructor
          */
         {{path|classsyntax}}Resource();
+
+        /*
+         * destructor
+         */
+         virtual ~{{path|classsyntax}}Resource();
     private:
         /*
          * function to make the payload for the retrieve function (e.g. GET) {{path}}
@@ -138,6 +145,23 @@ class {{path|classsyntax}}Resource : public Resource
          * @return OCEntityHandlerResult ok or not ok indication
          */
         OCEntityHandlerResult post(OC::QueryParamsMap queries, const OC::OCRepresentation& rep);
+
+        std::atomic<bool> m_notify_thread_active;
+        std::thread* m_notify_thread;
+
+        std::atomic<bool> m_send_notification_flag;
+        std::mutex m_cv_mutex;
+        std::condition_variable m_cv;
+
+        /*
+         * Function responsible for notifying all observers when a property
+         * on the resource has been changed.
+         * this function is running in a thread. Send a notification the
+         * m_send_notification_flag must be set to true and then m_cv.notify_all()
+         * must be called. This should automatically be handled by the code when
+         * PUT or POST is sent to the entityHandler.
+         */
+        void notifyObservers(void);
 
         // resource types and interfaces as array..
         std::string m_RESOURCE_TYPE[{{query_rt(json_data, path)|convert_array_size}}] = {{query_rt(json_data, path)|convert_to_c_type_array}}; // rt value (as an array)
@@ -172,7 +196,12 @@ class {{path|classsyntax}}Resource : public Resource
         virtual OCEntityHandlerResult entityHandler(std::shared_ptr<OC::OCResourceRequest> request);
 };
 
-{{path|classsyntax}}Resource::{{path|classsyntax}}Resource()
+{{path|classsyntax}}Resource::{{path|classsyntax}}Resource():
+    m_notify_thread_active(true),
+    m_notify_thread(nullptr),
+    m_send_notification_flag(false),
+    m_cv_mutex{},
+    m_cv{}
 {
     std::cout << "- Running: {{path|classsyntax}}Resource constructor" << std::endl;
     std::string resourceURI = "{{path}}";
@@ -219,6 +248,20 @@ class {{path|classsyntax}}Resource : public Resource
     {
         throw std::runtime_error(
             std::string("{{path|classsyntax}}Resource failed to start")+std::to_string(result));
+    }
+
+    m_send_notification_flag = false;
+    m_notify_thread_active = true;
+    m_notify_thread = new std::thread(&{{path|classsyntax}}Resource::notifyObservers, this);
+}
+
+{{path|classsyntax}}Resource::~{{path|classsyntax}}Resource()
+{
+    m_notify_thread_active = false;
+    m_cv.notify_all();
+    if(m_notify_thread->joinable())
+    {
+        m_notify_thread->join();
     }
 }
 
@@ -357,7 +400,8 @@ OCEntityHandlerResult {{path|classsyntax}}Resource::post(QueryParamsMap queries,
         try {
             if (rep.getValue(m_var_name{{var|variablesyntax}}, m_var_value{{var|variablesyntax}} ))
             {
-                std::cout << "\t\t" << "property '{{var}}': " << m_var_value{{var|variablesyntax}} << std::endl;
+                std::cout << "\t\t" << "property '{{var}}' UPDATED: " << ((m_var_value{{var|variablesyntax}}) ? "true" : "false") << std::endl;
+                m_send_notification_flag = true;
             }
             else
             {
@@ -374,6 +418,7 @@ OCEntityHandlerResult {{path|classsyntax}}Resource::post(QueryParamsMap queries,
             if (rep.getValue(m_var_name{{var|variablesyntax}}, m_var_value{{var|variablesyntax}} ))
             {
                 std::cout << "\t\t" << "property '{{var}}' UPDATED: " << m_var_value{{var|variablesyntax}} << std::endl;
+                m_send_notification_flag = true;
             }
             else
             {
@@ -389,7 +434,8 @@ OCEntityHandlerResult {{path|classsyntax}}Resource::post(QueryParamsMap queries,
             // value exist in payload
             if (rep.getValue(m_var_name{{var|variablesyntax}}, m_var_value{{var|variablesyntax}} ))
             {
-                std::cout << "\t\t" << "property '{{var}}': " << m_var_value{{var|variablesyntax}} << std::endl;
+                std::cout << "\t\t" << "property '{{var}}' UPDATED: " << m_var_value{{var|variablesyntax}} << std::endl;
+                m_send_notification_flag = true;
             }
             else
             {
@@ -404,7 +450,8 @@ OCEntityHandlerResult {{path|classsyntax}}Resource::post(QueryParamsMap queries,
         try {
             if (rep.getValue(m_var_name{{var|variablesyntax}}, m_var_value{{var|variablesyntax}} ))
             {
-                std::cout << "\t\t" << "property '{{var}}' : " << m_var_value{{var|variablesyntax}} << std::endl;
+                std::cout << "\t\t" << "property '{{var}}' UPDATED: " << m_var_value{{var|variablesyntax}} << std::endl;
+                m_send_notification_flag = true;
             }
             else
             {
@@ -423,7 +470,7 @@ OCEntityHandlerResult {{path|classsyntax}}Resource::post(QueryParamsMap queries,
             {
                 rep.getValue(m_var_name{{var|variablesyntax}}, m_var_value{{var|variablesyntax}});
                 int first = 1;
-                std::cout << "\t\t" << "property '{{var}}' : " ;
+                std::cout << "\t\t" << "property '{{var}}' UPDATED: " ;
                 for(auto myvar: m_var_value{{var|variablesyntax}})
                 {
                     if(first)
@@ -437,6 +484,7 @@ OCEntityHandlerResult {{path|classsyntax}}Resource::post(QueryParamsMap queries,
                     }
                 }
                 std::cout <<  std::endl;
+                m_send_notification_flag = true;
             }
             else
             {
@@ -448,6 +496,10 @@ OCEntityHandlerResult {{path|classsyntax}}Resource::post(QueryParamsMap queries,
             std::cout << e.what() << std::endl;
         }{% endif %}
     {% endfor %}
+        if (m_send_notification_flag)
+        {
+            m_cv.notify_all();
+        }
     }
     return ehResult;
 }
@@ -590,6 +642,23 @@ OCEntityHandlerResult {{path|classsyntax}}Resource::entityHandler(std::shared_pt
     }
     return ehResult;
 }
+
+void {{path|classsyntax}}Resource::notifyObservers(void)
+{
+    std::unique_lock<std::mutex> cv_lock(m_cv_mutex);
+    while (m_notify_thread_active)
+    {
+        m_cv.wait(cv_lock);
+        if (m_send_notification_flag)
+        {
+            m_send_notification_flag = false;
+            std::cout << "Send NOTIFICATION to all observers" << std::endl;
+
+            OCPlatform::notifyAllObservers(this->m_resourceHandle);
+        }
+    }
+}
+
 {% endfor %}
 
 class IoTServer


### PR DESCRIPTION
This adds in the code to handle when a notification
is sent to the observers. There are two variables that
handle starting and life time of the thread.

Three variables are used for controlling the when the
notification is sent. The two important variables are
the m_send_notification_flag and the condition_variable
m_cv.

When a value is changed via POST the m_send_notification_flag
is set to true. And m_cv.notify_all() is called to wake
the notification thread to send the notification.

The readme.md has been updated to indcate that the output now
supports notifications.

Signed-off-by: George Nash <george.nash@intel.com>