### PR TITLE
Fix logic in SleepConditionVariable in samples

### DIFF
--- a/src/templates/IOTivity-lite/simpleserver.c.jinja2
+++ b/src/templates/IOTivity-lite/simpleserver.c.jinja2
@@ -762,8 +762,11 @@ int init;
     if (next_event == 0) {
       SleepConditionVariableCS(&cv, &cs, INFINITE);
     } else {
-      SleepConditionVariableCS(&cv, &cs,
-                               (DWORD)(next_event / (1000 * OC_CLOCK_SECOND)));
+      oc_clock_time_t now = oc_clock_time();
+      if (now < next_event) {
+        SleepConditionVariableCS(&cv, &cs,
+                                 (DWORD)((next_event-now) * 1000 / OC_CLOCK_SECOND));
+      }
     }
   }
 #endif


### PR DESCRIPTION
The windows version of the samples were incorrectly
calculating the sleep time for the SleepConditionVariableCS
function.

See LITE-23 to see bug that lead to this code change.

Bug: https://jira.iotivity.org/browse/LITE-23
Signed-off-by: George Nash <george.nash@intel.com>